### PR TITLE
Recheck $number variable

### DIFF
--- a/Classes/DasOe/SimpleTeaser/Domain/Repository/TeaserRepository.php
+++ b/Classes/DasOe/SimpleTeaser/Domain/Repository/TeaserRepository.php
@@ -35,6 +35,9 @@ class TeaserRepository extends Repository {
         $idArray = $queryGetIdsQ->execute();
         shuffle($idArray);
         $idList = '';
+        if (count($idArray) < $number) {
+            $number = count($idArray);
+        }
         for ($i = 0; $i < $number; $i++) {
             $idList .= '\'' . $idArray[$i]['Persistence_Object_Identifier'] . '\',';
         }


### PR DESCRIPTION
If the $number is greater that the number of results than in for loop it will give undefined variable error